### PR TITLE
feat(GH-2): Add reusable workflows

### DIFF
--- a/.github/actions/artifact/download/README.md
+++ b/.github/actions/artifact/download/README.md
@@ -1,0 +1,24 @@
+# Download Tar Artifact
+Action: [download](./action.yml)
+
+The Download Tar Artifact action retrieves an artifact previously uploaded via the Upload Tar Artifact action, extracts the contents from the .tar archive, and restores the original file structure and permissions. It is useful for workflows where artifacts need to be transferred between jobs or workflows with file privileges intact.
+
+## Outputs
+| Name   | Description                                           | Required | Default |
+|--------|-------------------------------------------------------|----------|---------|
+| `name` | The name of the artifact to download.                 | false    |         |
+| `path` | The destination directory where the artifact is saved | false    |         |
+
+## Example
+```yaml
+jobs:
+  download-artifact:
+    name: Download Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish artifact
+        uses: cupel-co/actions/.github/actions/artifact/download@vX.X.X
+        with:
+          name: artifact
+          path: ./
+```

--- a/.github/actions/artifact/download/action.yml
+++ b/.github/actions/artifact/download/action.yml
@@ -1,16 +1,16 @@
-name: 'Download Tar Artifact'
-description: 'Download and extract a tar artifact that was previously uploaded in the workflow by the upload-tartifact action'
+name: Download Tar Artifact
+description: Download and extract a tar artifact that was previously uploaded in the workflow by the upload-tartifact action
 
 inputs:
   name:
-    description: 'Artifact name'
+    description: Artifact name
     required: false
   path:
-    description: 'Destination path'
+    description: Destination path
     required: false
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - uses: actions/download-artifact@v4
       with:

--- a/.github/actions/artifact/upload/README.md
+++ b/.github/actions/artifact/upload/README.md
@@ -1,0 +1,29 @@
+# OpenTofu Plan
+Action: [upload](./action.yml)
+
+The Upload Tar Artifact action compresses specified files or directories into a .tar archive and uploads the artifact, ensuring that file permissions are preserved. This is useful when file privileges need to remain intact across different environments or workflows. The action also allows specifying the artifact name, overwrite settings, and retention days.
+
+## Outputs
+| Name             | Description                                                                                                     | Required | Default |
+|------------------|-----------------------------------------------------------------------------------------------------------------|----------|---------|
+| `name`           | The name of the artifact.                                                                                       | true     |         |
+| `overwrite`      | Whether to overwrite an existing artifact with the same name.                                                   | false    | true    |
+| `path`           | A file, directory, or wildcard pattern describing what to upload. The file structure will be preserved via tar. | true     |         |
+| `retention-days` | The number of days after which the artifact will expire. 0 uses the default retention. Min: 1, Max: 90 days.    | false    |         |
+
+## Example
+```yaml
+jobs:
+  generate-version:
+    name: Generate Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish ${{ inputs.artifact-name }}
+        if: ${{ inputs.artifact-name != '' }}
+        uses: cupel-co/actions/artifact/upload@v0.5.0
+        with:
+          name: ${{ inputs.artifact-name }}
+          overwrite: true
+          path: ${{ inputs.working-directory }}
+          retention-days: 1
+```

--- a/.github/actions/artifact/upload/README.md
+++ b/.github/actions/artifact/upload/README.md
@@ -1,4 +1,4 @@
-# OpenTofu Plan
+# Upload Tar Artifact
 Action: [upload](./action.yml)
 
 The Upload Tar Artifact action compresses specified files or directories into a .tar archive and uploads the artifact, ensuring that file permissions are preserved. This is useful when file privileges need to remain intact across different environments or workflows. The action also allows specifying the artifact name, overwrite settings, and retention days.
@@ -14,16 +14,15 @@ The Upload Tar Artifact action compresses specified files or directories into a 
 ## Example
 ```yaml
 jobs:
-  generate-version:
-    name: Generate Version
+  upload-artifact:
+    name: Upload Artifact 
     runs-on: ubuntu-latest
     steps:
-      - name: Publish ${{ inputs.artifact-name }}
-        if: ${{ inputs.artifact-name != '' }}
-        uses: cupel-co/actions/artifact/upload@v0.5.0
+      - name: Publish artifact
+        uses: cupel-co/actions/.github/actions/artifact/upload@vX.X.X
         with:
-          name: ${{ inputs.artifact-name }}
+          name: artifact
           overwrite: true
-          path: ${{ inputs.working-directory }}
+          path: ./
           retention-days: 1
 ```

--- a/.github/actions/artifact/upload/action.yml
+++ b/.github/actions/artifact/upload/action.yml
@@ -1,12 +1,12 @@
-name: 'Upload Tar Artifact'
-description: 'Compress files with tar prior to artifacting to keep file privileges.'
+name: Upload Tar Artifact
+description: Compress files with tar prior to artifacting to keep file privileges.
 
 inputs:
   name:
     description: Artifact name
     required: true
   overwrite:
-    description: Artifact name
+    description: Whether to overwrite an existing artifact with the same name
     default: 'true'
   path:
     description: >

--- a/.github/actions/artifact/upload/action.yml
+++ b/.github/actions/artifact/upload/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - run: |
         shopt -s globstar

--- a/.github/actions/version/generate/README.md
+++ b/.github/actions/version/generate/README.md
@@ -1,4 +1,4 @@
-# OpenTofu Plan
+# Generate Semantic Version
 Action: [generate](./action.yml)
 
 The Generate Semantic Version GitHub Action uses GitVersion to generate semantic versioning information for a project. It calculates and outputs detailed versioning components such as major, minor, patch, pre-release tags, build metadata, and commit information. The action ensures that versioning is automatically derived based on Git history, which can then be used for various purposes like tagging releases or setting version numbers in a project.
@@ -45,5 +45,5 @@ jobs:
           fetch-tags: true
       - name: Generate version
         id: generate
-        uses: ./version/generate
+        uses: cupel-co/actions/.github/actions/version/generate@vX.X.X
 ```

--- a/.github/actions/version/generate/README.md
+++ b/.github/actions/version/generate/README.md
@@ -1,0 +1,49 @@
+# OpenTofu Plan
+Action: [generate](./action.yml)
+
+The Generate Semantic Version GitHub Action uses GitVersion to generate semantic versioning information for a project. It calculates and outputs detailed versioning components such as major, minor, patch, pre-release tags, build metadata, and commit information. The action ensures that versioning is automatically derived based on Git history, which can then be used for various purposes like tagging releases or setting version numbers in a project.
+
+## Outputs
+| Name                           | Description                              |
+|--------------------------------|------------------------------------------|
+| `major`                        | The Major value                          |
+| `minor`                        | The Minor value                          |
+| `patch`                        | The Patch value                          |
+| `pre-release-tag`              | The prerelease tag value                 |
+| `pre-release-tag-with-dash`    | The prerelease tag with dash value       |
+| `pre-release-label`            | The prerelease label value               |
+| `pre-release-number`           | The prerelease number value              |
+| `weighted-pre-release-number`  | The weighted prerelease number value     |
+| `build-meta-data`              | The build metadata value                 |
+| `full-build-meta-data`         | The full build metadata value            |
+| `major-minor-patch`            | The major-minor-patch value              |
+| `sem-ver`                      | The semantic version value               |
+| `assembly-sem-ver`             | The assembly semantic version value      |
+| `assembly-sem-file-ver`        | The assembly file semantic version value |
+| `full-sem-ver`                 | The full semantic version value          |
+| `informational-version`        | The informational version value          |
+| `branch-name`                  | The branch name value                    |
+| `escaped-branch-name`          | The escaped branch name value            |
+| `sha`                          | The sha value                            |
+| `short-sha`                    | The short sha value                      |
+| `version-source-sha`           | The version source sha value             |
+| `commits-since-version-source` | The commits since version source value   |
+| `uncommitted-changes`          | The uncommitted changes value            |
+| `commit-date`                  | The commit date value                    |
+
+## Example
+```yaml
+jobs:
+  generate-version:
+    name: Generate Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Generate version
+        id: generate
+        uses: ./version/generate
+```

--- a/.github/actions/version/generate/action.yml
+++ b/.github/actions/version/generate/action.yml
@@ -1,79 +1,79 @@
 name: Generate Semantic Version
 description: Generate Semantic Version
-    
+
 outputs:
   major:
     description: 'The Major value'
-    value: ${{ steps.generate.outputs.major }}
+    value: ${{ steps.generate-version.outputs.major }}
   minor:
     description: 'The Minor value'
-    value: ${{ steps.generate.outputs.minor }}
+    value: ${{ steps.generate-version.outputs.minor }}
   patch:
     description: 'The Patch value'
-    value: ${{ steps.generate.outputs.patch }}
-  preReleaseTag:
-    description: 'The PreReleaseTag value'
-    value: ${{ steps.generate.outputs.preReleaseTag }}
-  preReleaseTagWithDash:
-    description: 'The PreReleaseTagWithDash value'
-    value: ${{ steps.generate.outputs.preReleaseTagWithDash }}
-  preReleaseLabel:
-    description: 'The PreReleaseLabel value'
-    value: ${{ steps.generate.outputs.preReleaseLabel }}
-  preReleaseNumber:
-    description: 'The PreReleaseNumber value'
-    value: ${{ steps.generate.outputs.preReleaseNumber }}
-  weightedPreReleaseNumber:
-    description: 'The WeightedPreReleaseNumber value'
-    value: ${{ steps.generate.outputs.weightedPreReleaseNumber }}
-  buildMetaData:
-    description: 'The BuildMetaData value'
-    value: ${{ steps.generate.outputs.buildMetaData }}
-  fullBuildMetaData:
-    description: 'The FullBuildMetaData value'
-    value: ${{ steps.generate.outputs.fullBuildMetaData }}
-  majorMinorPatch:
-    description: 'The MajorMinorPatch value'
-    value: ${{ steps.generate.outputs.majorMinorPatch }}
-  semVer:
-    description: 'The SemVer value'
-    value: ${{ steps.generate.outputs.semVer }}
-  assemblySemVer:
-    description: 'The AssemblySemVer value'
-    value: ${{ steps.generate.outputs.assemblySemVer }}
-  assemblySemFileVer:
-    description: 'The AssemblySemFileVer value'
-    value: ${{ steps.generate.outputs.assemblySemFileVer }}
-  fullSemVer:
-    description: 'The FullSemVer value'
-    value: ${{ steps.generate.outputs.fullSemVer }}
-  informationalVersion:
-    description: 'The InformationalVersion value'
-    value: ${{ steps.generate.outputs.informationalVersion }}
-  branchName:
-    description: 'The BranchName value'
-    value: ${{ steps.generate.outputs.branchName }}
-  escapedBranchName:
-    description: 'The EscapedBranchName value'
-    value: ${{ steps.generate.outputs.escapedBranchName }}
+    value: ${{ steps.generate-version.outputs.patch }}
+  pre-release-tag:
+    description: 'The prerelease tag value'
+    value: ${{ steps.generate-version.outputs.pre-release-tag }}
+  pre-release-tag-with-dash :
+    description: 'The prerelease tag with dash value'
+    value: ${{ steps.generate-version.outputs.pre-release-tag-with-dash }}
+  pre-release-label:
+    description: 'The prerelease lable value'
+    value: ${{ steps.generate-version.outputs.pre-release-label }}
+  pre-release-number:
+    description: 'The prerelease number value'
+    value: ${{ steps.generate-version.outputs.pre-release-number }}
+  weighted-pre-release-number:
+    description: 'The weighted prerelease number value'
+    value: ${{ steps.generate-version.outputs.weighted-pre-release-number }}
+  build-meta-data:
+    description: 'The build metadata value'
+    value: ${{ steps.generate-version.outputs.build-meta-data }}
+  full-build-meta-data:
+    description: 'The full build metadata value'
+    value: ${{ steps.generate-version.outputs.full-build-meta-data }}
+  major-minor-patch:
+    description: 'The major minor patch value'
+    value: ${{ steps.generate-version.outputs.major-minor-patch }}
+  sem-ver:
+    description: 'The semantic version value'
+    value: ${{ steps.generate-version.outputs.sem-ver }}
+  assembly-sem-ver:
+    description: 'The assembly semantic version value'
+    value: ${{ steps.generate-version.outputs.assembly-sem-ver }}
+  assembly-sem-file-ver:
+    description: 'The file assembly semantic version value'
+    value: ${{ steps.generate-version.outputs.assembly-sem-file-ver }}
+  full-sem-ver:
+    description: 'The full semantic version value'
+    value: ${{ steps.generate-version.outputs.full-sem-ver }}
+  informational-version:
+    description: 'The informational version value'
+    value: ${{ steps.generate-version.outputs.informational-version }}
+  branch-name:
+    description: 'The branch name value'
+    value: ${{ steps.generate-version.outputs.branch-nam }}
+  escaped-branch-name:
+    description: 'The escaped branch name value'
+    value: ${{ steps.generate-version.outputs.escaped-branch-name }}
   sha:
-    description: 'The Sha value'
-    value: ${{ steps.generate.outputs.sha }}
-  shortSha:
-    description: 'The ShortSha value'
-    value: ${{ steps.generate.outputs.shortSha }}
-  versionSourceSha:
-    description: 'The VersionSourceSha value'
-    value: ${{ steps.generate.outputs.versionSourceSha }}
-  commitsSinceVersionSource:
-    description: 'The CommitsSinceVersionSource value'
-    value: ${{ steps.generate.outputs.commitsSinceVersionSource }}
-  uncommittedChanges:
-    description: 'The UncommittedChanges value'
-    value: ${{ steps.generate.outputs.uncommittedChanges }}
-  commitDate:
-    description: 'The CommitDate value'
-    value: ${{ steps.generate.outputs.commitDate }}
+    description: 'The sha value'
+    value: ${{ steps.generate-version.outputs.sha }}
+  short-sha:
+    description: 'The short sha value'
+    value: ${{ steps.generate-version.outputs.short-sha }}
+  version-source-sha:
+    description: 'The version source sha value'
+    value: ${{ steps.generate-version.outputs.version-source-sha }}
+  commits-since-version-source:
+    description: 'The commits since version source value'
+    value: ${{ steps.generate-version.outputs.commits-since-version-source }}
+  uncommitted-changes:
+    description: 'The uncommitted changes value'
+    value: ${{ steps.generate-version.outputs.uncommitted-changes }}
+  commit-date:
+    description: 'The commit date value'
+    value: ${{ steps.generate-version.outputs.commit-date }}
 
 runs:
   using: composite

--- a/.github/actions/version/generate/action.yml
+++ b/.github/actions/version/generate/action.yml
@@ -4,87 +4,86 @@ description: Generate Semantic Version
 outputs:
   major:
     description: 'The Major value'
-    value: ${{ steps.get-version.outputs.major }}
+    value: ${{ steps.generate.outputs.major }}
   minor:
     description: 'The Minor value'
-    value: ${{ steps.get-version.outputs.minor }}
+    value: ${{ steps.generate.outputs.minor }}
   patch:
     description: 'The Patch value'
-    value: ${{ steps.get-version.outputs.patch }}
+    value: ${{ steps.generate.outputs.patch }}
   preReleaseTag:
     description: 'The PreReleaseTag value'
-    value: ${{ steps.get-version.outputs.preReleaseTag }}
+    value: ${{ steps.generate.outputs.preReleaseTag }}
   preReleaseTagWithDash:
     description: 'The PreReleaseTagWithDash value'
-    value: ${{ steps.get-version.outputs.preReleaseTagWithDash }}
+    value: ${{ steps.generate.outputs.preReleaseTagWithDash }}
   preReleaseLabel:
     description: 'The PreReleaseLabel value'
-    value: ${{ steps.get-version.outputs.preReleaseLabel }}
+    value: ${{ steps.generate.outputs.preReleaseLabel }}
   preReleaseNumber:
     description: 'The PreReleaseNumber value'
-    value: ${{ steps.get-version.outputs.preReleaseNumber }}
+    value: ${{ steps.generate.outputs.preReleaseNumber }}
   weightedPreReleaseNumber:
     description: 'The WeightedPreReleaseNumber value'
-    value: ${{ steps.get-version.outputs.weightedPreReleaseNumber }}
+    value: ${{ steps.generate.outputs.weightedPreReleaseNumber }}
   buildMetaData:
     description: 'The BuildMetaData value'
-    value: ${{ steps.get-version.outputs.buildMetaData }}
+    value: ${{ steps.generate.outputs.buildMetaData }}
   fullBuildMetaData:
     description: 'The FullBuildMetaData value'
-    value: ${{ steps.get-version.outputs.fullBuildMetaData }}
+    value: ${{ steps.generate.outputs.fullBuildMetaData }}
   majorMinorPatch:
     description: 'The MajorMinorPatch value'
     value: ${{ steps.generate.outputs.majorMinorPatch }}
   semVer:
     description: 'The SemVer value'
-    value: ${{ steps.get-version.outputs.semVer }}
+    value: ${{ steps.generate.outputs.semVer }}
   assemblySemVer:
     description: 'The AssemblySemVer value'
-    value: ${{ steps.get-version.outputs.assemblySemVer }}
+    value: ${{ steps.generate.outputs.assemblySemVer }}
   assemblySemFileVer:
     description: 'The AssemblySemFileVer value'
-    value: ${{ steps.get-version.outputs.assemblySemFileVer }}
+    value: ${{ steps.generate.outputs.assemblySemFileVer }}
   fullSemVer:
     description: 'The FullSemVer value'
-    value: ${{ steps.get-version.outputs.fullSemVer }}
+    value: ${{ steps.generate.outputs.fullSemVer }}
   informationalVersion:
     description: 'The InformationalVersion value'
-    value: ${{ steps.get-version.outputs.informationalVersion }}
+    value: ${{ steps.generate.outputs.informationalVersion }}
   branchName:
     description: 'The BranchName value'
-    value: ${{ steps.get-version.outputs.branchName }}
+    value: ${{ steps.generate.outputs.branchName }}
   escapedBranchName:
     description: 'The EscapedBranchName value'
-    value: ${{ steps.get-version.outputs.escapedBranchName }}
+    value: ${{ steps.generate.outputs.escapedBranchName }}
   sha:
     description: 'The Sha value'
-    value: ${{ steps.get-version.outputs.sha }}
+    value: ${{ steps.generate.outputs.sha }}
   shortSha:
     description: 'The ShortSha value'
-    value: ${{ steps.get-version.outputs.shortSha }}
+    value: ${{ steps.generate.outputs.shortSha }}
   versionSourceSha:
     description: 'The VersionSourceSha value'
-    value: ${{ steps.get-version.outputs.versionSourceSha }}
+    value: ${{ steps.generate.outputs.versionSourceSha }}
   commitsSinceVersionSource:
     description: 'The CommitsSinceVersionSource value'
-    value: ${{ steps.get-version.outputs.commitsSinceVersionSource }}
+    value: ${{ steps.generate.outputs.commitsSinceVersionSource }}
   uncommittedChanges:
     description: 'The UncommittedChanges value'
-    value: ${{ steps.get-version.outputs.uncommittedChanges }}
+    value: ${{ steps.generate.outputs.uncommittedChanges }}
   commitDate:
     description: 'The CommitDate value'
-    value: ${{ steps.get-version.outputs.commitDate }}
+    value: ${{ steps.generate.outputs.commitDate }}
 
 runs:
   using: composite
   steps:
-    - name: Install GitVersion
+    - name: Install
       uses: gittools/actions/gitversion/setup@v1.1.1
       with:
         versionSpec: '5.x'
-
-    - name: Get version
-      id: get-version
+    - name: Generate
+      id: generate
       uses: gittools/actions/gitversion/execute@v1.1.1
       with:
         targetPath: ./

--- a/.github/actions/version/generate/action.yml
+++ b/.github/actions/version/generate/action.yml
@@ -4,76 +4,76 @@ description: Generate Semantic Version
 outputs:
   major:
     description: 'The Major value'
-    value: ${{ steps.generate-version.outputs.major }}
+    value: ${{ steps.generate.outputs.major }}
   minor:
     description: 'The Minor value'
-    value: ${{ steps.generate-version.outputs.minor }}
+    value: ${{ steps.generate.outputs.minor }}
   patch:
     description: 'The Patch value'
-    value: ${{ steps.generate-version.outputs.patch }}
+    value: ${{ steps.generate.outputs.patch }}
   pre-release-tag:
     description: 'The prerelease tag value'
-    value: ${{ steps.generate-version.outputs.pre-release-tag }}
+    value: ${{ steps.generate.outputs.pre-release-tag }}
   pre-release-tag-with-dash :
     description: 'The prerelease tag with dash value'
-    value: ${{ steps.generate-version.outputs.pre-release-tag-with-dash }}
+    value: ${{ steps.generate.outputs.pre-release-tag-with-dash }}
   pre-release-label:
     description: 'The prerelease lable value'
-    value: ${{ steps.generate-version.outputs.pre-release-label }}
+    value: ${{ steps.generate.outputs.pre-release-label }}
   pre-release-number:
     description: 'The prerelease number value'
-    value: ${{ steps.generate-version.outputs.pre-release-number }}
+    value: ${{ steps.generate.outputs.pre-release-number }}
   weighted-pre-release-number:
     description: 'The weighted prerelease number value'
-    value: ${{ steps.generate-version.outputs.weighted-pre-release-number }}
+    value: ${{ steps.generate.outputs.weighted-pre-release-number }}
   build-meta-data:
     description: 'The build metadata value'
-    value: ${{ steps.generate-version.outputs.build-meta-data }}
+    value: ${{ steps.generate.outputs.build-meta-data }}
   full-build-meta-data:
     description: 'The full build metadata value'
-    value: ${{ steps.generate-version.outputs.full-build-meta-data }}
+    value: ${{ steps.generate.outputs.full-build-meta-data }}
   major-minor-patch:
     description: 'The major minor patch value'
-    value: ${{ steps.generate-version.outputs.major-minor-patch }}
+    value: ${{ steps.generate.outputs.major-minor-patch }}
   sem-ver:
     description: 'The semantic version value'
-    value: ${{ steps.generate-version.outputs.sem-ver }}
+    value: ${{ steps.generate.outputs.sem-ver }}
   assembly-sem-ver:
     description: 'The assembly semantic version value'
-    value: ${{ steps.generate-version.outputs.assembly-sem-ver }}
+    value: ${{ steps.generate.outputs.assembly-sem-ver }}
   assembly-sem-file-ver:
     description: 'The file assembly semantic version value'
-    value: ${{ steps.generate-version.outputs.assembly-sem-file-ver }}
+    value: ${{ steps.generate.outputs.assembly-sem-file-ver }}
   full-sem-ver:
     description: 'The full semantic version value'
-    value: ${{ steps.generate-version.outputs.full-sem-ver }}
+    value: ${{ steps.generate.outputs.full-sem-ver }}
   informational-version:
     description: 'The informational version value'
-    value: ${{ steps.generate-version.outputs.informational-version }}
+    value: ${{ steps.generate.outputs.informational-version }}
   branch-name:
     description: 'The branch name value'
-    value: ${{ steps.generate-version.outputs.branch-nam }}
+    value: ${{ steps.generate.outputs.branch-nam }}
   escaped-branch-name:
     description: 'The escaped branch name value'
-    value: ${{ steps.generate-version.outputs.escaped-branch-name }}
+    value: ${{ steps.generate.outputs.escaped-branch-name }}
   sha:
     description: 'The sha value'
-    value: ${{ steps.generate-version.outputs.sha }}
+    value: ${{ steps.generate.outputs.sha }}
   short-sha:
     description: 'The short sha value'
-    value: ${{ steps.generate-version.outputs.short-sha }}
+    value: ${{ steps.generate.outputs.short-sha }}
   version-source-sha:
     description: 'The version source sha value'
-    value: ${{ steps.generate-version.outputs.version-source-sha }}
+    value: ${{ steps.generate.outputs.version-source-sha }}
   commits-since-version-source:
     description: 'The commits since version source value'
-    value: ${{ steps.generate-version.outputs.commits-since-version-source }}
+    value: ${{ steps.generate.outputs.commits-since-version-source }}
   uncommitted-changes:
     description: 'The uncommitted changes value'
-    value: ${{ steps.generate-version.outputs.uncommitted-changes }}
+    value: ${{ steps.generate.outputs.uncommitted-changes }}
   commit-date:
     description: 'The commit date value'
-    value: ${{ steps.generate-version.outputs.commit-date }}
+    value: ${{ steps.generate.outputs.commit-date }}
 
 runs:
   using: composite

--- a/.github/actions/version/generate/action.yml
+++ b/.github/actions/version/generate/action.yml
@@ -34,7 +34,7 @@ outputs:
     value: ${{ steps.get-version.outputs.fullBuildMetaData }}
   majorMinorPatch:
     description: 'The MajorMinorPatch value'
-    value: ${{ steps.get-version.outputs.majorMinorPatch }}
+    value: ${{ steps.generate.outputs.majorMinorPatch }}
   semVer:
     description: 'The SemVer value'
     value: ${{ steps.get-version.outputs.semVer }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # GH-{{ISSUE_IDENTIFIER}} - {{ISSUE_TITLE}}
 
-![Pipeline](https://github.com/cupel-co/actions/actions/workflows/preview.yml/badge.svg?event=pull_request&branch={{BRANCH_NAME}}))
+[![Preview](https://github.com/cupel-co/platform-opentofu-aws-backend/actions/workflows/preview.yml/badge.svg?branch={{BRANCH_NAME}}&event=pull_request)](https://github.com/cupel-co/actions/actions/workflows/preview.yml?branch={{BRANCH_NAME}})
 
 ## Description
 *

--- a/.github/workflows/generate-version.yml
+++ b/.github/workflows/generate-version.yml
@@ -1,0 +1,116 @@
+name: 'Preview'
+
+on:
+  workflow_call:
+    outputs:
+      major:
+        description: 'The Major value'
+        value: ${{ jobs.generate-version.outputs.major }}
+      minor:
+        description: 'The Minor value'
+        value: ${{ jobs.generate-version.outputs.minor }}
+      patch:
+        description: 'The Patch value'
+        value: ${{ jobs.generate-version.outputs.patch }}
+      pre-release-tag:
+        description: 'The prerelease tag value'
+        value: ${{ jobs.generate-version.outputs.pre-release-tag }}
+      pre-release-tag-with-dash :
+        description: 'The prerelease tag with dash value'
+        value: ${{ jobs.generate-version.outputs.pre-release-tag-with-dash }}
+      pre-release-label:
+        description: 'The prerelease lable value'
+        value: ${{ jobs.generate-version.outputs.pre-release-label }}
+      pre-release-number:
+        description: 'The prerelease number value'
+        value: ${{ jobs.generate-version.outputs.pre-release-number }}
+      weighted-pre-release-number:
+        description: 'The weighted prerelease number value'
+        value: ${{ jobs.generate-version.outputs.weighted-pre-release-number }}
+      build-meta-data:
+        description: 'The build metadata value'
+        value: ${{ jobs.generate-version.outputs.build-meta-data }}
+      full-build-meta-data:
+        description: 'The full build metadata value'
+        value: ${{ jobs.generate-version.outputs.full-build-meta-data }}
+      major-minor-patch:
+        description: 'The major minor patch value'
+        value: ${{ jobs.generate-version.outputs.major-minor-patch }}
+      sem-ver:
+        description: 'The semantic version value'
+        value: ${{ jobs.generate-version.outputs.sem-ver }}
+      assembly-sem-ver:
+        description: 'The assembly semantic version value'
+        value: ${{ jobs.generate-version.outputs.assembly-sem-ver }}
+      assembly-sem-file-ver:
+        description: 'The file assembly semantic version value'
+        value: ${{ jobs.generate-version.outputs.assembly-sem-file-ver }}
+      full-sem-ver:
+        description: 'The full semantic version value'
+        value: ${{ jobs.generate-version.outputs.full-sem-ver }}
+      informational-version:
+        description: 'The informational version value'
+        value: ${{ jobs.generate-version.outputs.informational-version }}
+      branch-name:
+        description: 'The branch name value'
+        value: ${{ jobs.generate-version.outputs.branch-nam }}
+      escaped-branch-name:
+        description: 'The escaped branch name value'
+        value: ${{ jobs.generate-version.outputs.escaped-branch-name }}
+      sha:
+        description: 'The sha value'
+        value: ${{ jobs.generate-version.outputs.sha }}
+      short-sha:
+        description: 'The short sha value'
+        value: ${{ jobs.generate-version.outputs.short-sha }}
+      version-source-sha:
+        description: 'The version source sha value'
+        value: ${{ jobs.generate-version.outputs.version-source-sha }}
+      commits-since-version-source:
+        description: 'The commits since version source value'
+        value: ${{ jobs.generate-version.outputs.commits-since-version-source }}
+      uncommitted-changes:
+        description: 'The uncommitted changes value'
+        value: ${{ jobs.generate-version.outputs.uncommitted-changes }}
+      commit-date:
+        description: 'The commit date value'
+        value: ${{ jobs.generate-version.outputs.commit-date }}
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    outputs:
+      major: ${{ steps.generate.outputs.major }}
+      minor: ${{ steps.generate.outputs.minor }}
+      patch: ${{ steps.generate.outputs.patch }}
+      pre-release-tag: ${{ steps.generate.outputs.pre-release-tag }}
+      pre-release-tag-with-dash: ${{ steps.generate.outputs.pre-release-tag-with-dash }}
+      pre-release-label: ${{ steps.generate.outputs.pre-release-label }}
+      pre-release-number: ${{ steps.generate.outputs.pre-release-number }}
+      weighted-pre-release-number: ${{ steps.generate.outputs.weighted-pre-release-number }}
+      build-meta-data: ${{ steps.generate.outputs.build-meta-data }}
+      full-build-meta-data: ${{ steps.generate.outputs.full-build-meta-data }}
+      major-minor-patch: ${{ steps.generate.outputs.major-minor-patch }}
+      sem-ver: ${{ steps.generate.outputs.sem-ver }}
+      assembly-sem-ver: ${{ steps.generate.outputs.assembly-sem-ver }}
+      assembly-sem-file-ver: ${{ steps.generate.outputs.assembly-sem-file-ver }}
+      full-sem-ver: ${{ steps.generate.outputs.full-sem-ver }}
+      informational-version: ${{ steps.generate.outputs.informational-version }}
+      branch-name: ${{ steps.generate.outputs.branch-name }}
+      escaped-branch-name: ${{ steps.generate.outputs.escaped-branch-name }}
+      sha: ${{ steps.generate.outputs.sha }}
+      short-sha: ${{ steps.generate.outputs.short-sha }}
+      version-source-sha: ${{ steps.generate.outputs.version-source-sha }}
+      commits-since-version-source: ${{ steps.generate.outputs.commits-since-version-source }}
+      uncommitted-changes: ${{ steps.generate.outputs.uncommitted-changes }}
+      commit-date: ${{ steps.generate.outputs.commit-date }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Generate
+        id: generate
+        uses: ./.github/actions/version/generate

--- a/.github/workflows/notify-pull-request.yml
+++ b/.github/workflows/notify-pull-request.yml
@@ -9,7 +9,6 @@ on:
     secrets:
       google-chat-webhook-url:
         required: true
-        type: string
 
 jobs:
   notify:

--- a/.github/workflows/notify-pull-request.yml
+++ b/.github/workflows/notify-pull-request.yml
@@ -5,20 +5,24 @@ on:
     types:
       - opened
       - reopened
-
-concurrency:
-  cancel-in-progress: false
-  group: pull-request-opened-${{ github.ref_name }}
+  workflow_call:
+    secrets:
+      google-chat-webhook-url:
+        required: true
+        type: string
 
 jobs:
-  update:
+  notify:
     name: Send notification
     runs-on: ubuntu-latest
+    concurrency:
+      cancel-in-progress: false
+      group: pull-request-notify-${{ github.ref_name }}
     steps:
       - name: Notify Google Chat
         if: ${{ always() }}
         uses: SimonScholz/google-chat-action@main
         with:
-          webhookUrl: '${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}'
+          webhookUrl: ${{ secrets.google-chat-webhook-url != '' && secrets.google-chat-webhook-url || secrets.GOOGLE_CHAT_WEBHOOK_URL }}
           title: 'Pull request ${{ github.event.action }}'
           subtitle: ${{ github.event.pull_request.title }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,17 +8,6 @@ on:
       - synchronize
 
 jobs:
-  generate-version:
-    name: Generate Version
-    runs-on: ubuntu-latest
-    outputs:
-      sem-ver: ${{ steps.get-version.outputs.semVer }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - name: Generate version
-        id: get-version
-        uses: ./version/generate
+  version:
+    name: Generate
+    uses: ./.github/workflows/generate-version.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,55 +8,18 @@ on:
 jobs:
   generate-version:
     uses: ./.github/workflows/generate-version.yml
-    outputs:
-      sem-ver: ${{ steps.get-version.outputs.sem-ver }}
 
   production:
-    name: Production
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/tag.yml
     needs:
       - generate-version
+    name: Production
+    environment: Production
     env:
       tag: v${{ needs.generate-version.outputs.sem-ver }}
-    environment: Production
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GH_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GH_GPG_PRIVATE_KEY_PASSWORD }}
-          git_user_signingkey: true
-          git_tag_gpgsign: true
-      - name: Create and push tag
-        run: |
-          git tag -s ${{ env.tag }} -m "${{ env.tag }}"
-          git push origin tag ${{ env.tag }}
-      - name: Generate changelog
-        id: changelog
-        uses: requarks/changelog-action@v1
-        with:
-          token: ${{ github.token }}
-          tag: ${{ env.tag }}
-          writeToFile: false
-          includeInvalidCommits: true
-      - name: Create release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: "${{ steps.changelog.outputs.changes }}"
-          tag_name: ${{ env.tag }}
-          make_latest: true
-      - name: Notify Google Chat
-        if: ${{ always() }}
-        uses: SimonScholz/google-chat-action@main
-        with:
-          webhookUrl: '${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}'
-          title: Released ${{ env.tag }}
-          subtitle: ${{ github.event.head_commit.message }}
-          jobStatus: '${{ job.status }}'
+    with:
+      tag: ${{ env.tag }}
+    secrets:
+      gh-gpg-private-key: ${{ secrets.GH_GPG_PRIVATE_KEY }}
+      gh-gpg-private-key-password: ${{ secrets.GH_GPG_PRIVATE_KEY_PASSWORD }}
+      google-chat-webhook-url: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,20 +7,10 @@ on:
 
 jobs:
   generate-version:
-    name: Generate Version
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/generate-version.yml
     outputs:
-      sem-ver: ${{ steps.get-version.outputs.semVer }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - name: Generate version
-        id: get-version
-        uses: ./version/generate
-  
+      sem-ver: ${{ steps.get-version.outputs.sem-ver }}
+
   production:
     name: Production
     runs-on: ubuntu-latest

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,61 @@
+name: 'Tag'
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+    secrets:
+      gh-gpg-private-key:
+        required: true
+      gh-gpg-private-key-password:
+        required: true
+      google-chat-webhook-url:
+        required: true
+
+jobs:
+  tag:
+    name: Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.gh-gpg-private-key }}
+          passphrase: ${{ secrets.gh-gpg-private-key-password }}
+          git_user_signingkey: true
+          git_tag_gpgsign: true
+      - name: Create and push tag
+        run: |
+          git tag -s ${{ inputs.tag }} -m "${{ inputs.tag }}"
+          git push origin tag ${{ inputs.tag }}
+      - name: Generate changelog
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          tag: ${{ inputs.tag }}
+          writeToFile: false
+          includeInvalidCommits: true
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: "${{ steps.changelog.outputs.changes }}"
+          tag_name: ${{ inputs.tag }}
+          make_latest: true
+      - name: Notify Google Chat
+        if: ${{ always() }}
+        uses: SimonScholz/google-chat-action@main
+        with:
+          webhookUrl: '${{ secrets.google-chat-webhook-url }}'
+          title: Released ${{ inputs.tag }}
+          subtitle: ${{ github.event.head_commit.message }}
+          jobStatus: '${{ job.status }}'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # Actions
 A collection of reusable GitHub actions
+
+## Actions
+* [download artifact](.github/actions/artifact/download/README.md)
+* [upload artifact](.github/actions/artifact/upload/README.md)
+* [generate version](.github/actions/version/generate/README.md)
+
+## Workflows
+* [generate-version.yml](.github/workflows/generate-version.yml)
+* [notify-pull-request.yml](.github/workflows/notify-pull-request.yml)
+* [tag.yml](.github/workflows/tag.yml)


### PR DESCRIPTION
# GH-2 - Add reusable workflows

[![Preview](https://github.com/cupel-co/platform-opentofu-aws-backend/actions/workflows/preview.yml/badge.svg?branch=feature/GH-2-add-reusable-workflows&event=pull_request)](https://github.com/cupel-co/platform-opentofu-aws-backend/actions/workflows/preview.yml?branch=feature/GH-2-add-reusable-workflows) 

## Description
* 
* 
* 

## Testing
- [ ] Planned changes for all workspaces
- [ ] Reviewed proposed changes
