### PR TITLE
docs(readme): Fix examples to reference the right action for the newly added infracost actions

### DIFF
--- a/.github/actions/infracost/comment/README.md
+++ b/.github/actions/infracost/comment/README.md
@@ -15,12 +15,12 @@ Add a comment to a GitHub PR
 ## Example
 ```yaml
 jobs:
-  generate:
-    name: Generate
+  comment:
+    name: Comment
     runs-on: ubuntu-latest
     steps:
-      - name: Diff
-        uses: cupel-co/actions/.github/actions/infracost/breakdown@vX.X.X
+      - name: Comment
+        uses: cupel-co/actions/.github/actions/infracost/comment@vX.X.X
         with:
           api-key: "${{ secrets.INFRACOST_API_KEY }}"
           base-breakdown-path: /tmp/main.json

--- a/.github/actions/infracost/diff/README.md
+++ b/.github/actions/infracost/diff/README.md
@@ -16,12 +16,12 @@ Generate a cost difference between the old and new change
 ## Example
 ```yaml
 jobs:
-  generate:
-    name: Generate
+  diff:
+    name: Diff
     runs-on: ubuntu-latest
     steps:
       - name: Diff
-        uses: cupel-co/actions/.github/actions/infracost/breakdown@vX.X.X
+        uses: cupel-co/actions/.github/actions/infracost/diff@vX.X.X
         with:
           api-key: "${{ secrets.INFRACOST_API_KEY }}"
           base-breakdown-path: /tmp/main.json


### PR DESCRIPTION
# GH-14 - docs(readme): Fix examples to reference the right action for the newly added infracost actions

[![Preview](https://github.com/cupel-co/actions/actions/workflows/preview.yml/badge.svg?branch=docs/GH-15-fix-readmes&event=pull_request)](https://github.com/cupel-co/actions/actions/workflows/preview.yml?query=branch%3Adocs/GH-15-fix-readmes)

## Description
* docs(readme): Fix examples to reference the right action for the newly added infracost actions
* closes GH-14

## Testing
- [ ] Planned changes for all workspaces
- [ ] Reviewed proposed changes
