### PR TITLE
feat(actions): Add usage file support for infracost

### DIFF
--- a/.github/actions/infracost/breakdown/README.md
+++ b/.github/actions/infracost/breakdown/README.md
@@ -10,8 +10,9 @@ Generate a cost breakdown for the specified infrastructure
 | `currency`         | The currency to show estimates in   | false    | `AUD`              |
 | `output-path`      | The file path for the JSON file     | false    | `./infracost.json` |
 | `template`         | The infracost template              | false    |                    |
-| `workspace-prefix` | The prefix for the workspace name   | false    |                    |
+| `usage`            | The usage file contents             | false    |                    |
 | `version`          | The version of Infracost to install | false    | `0.10.x`           |
+| `workspace-prefix` | The prefix for the workspace name   | false    |                    |
 
 ## Example
 ```yaml

--- a/.github/actions/infracost/breakdown/action.yml
+++ b/.github/actions/infracost/breakdown/action.yml
@@ -20,8 +20,8 @@ inputs:
     required: false
     type: string
     default: ""
-  workspace-prefix:
-    description: The prefix for the workspace name
+  usage:
+    description: The usage file contents
     required: false
     type: string
     default: ""
@@ -30,6 +30,11 @@ inputs:
     default: 0.10.x
     required: false
     type: string
+  workspace-prefix:
+    description: The prefix for the workspace name
+    required: false
+    type: string
+    default: ""
 
 runs:
   using: composite
@@ -67,7 +72,26 @@ runs:
         }
 
         infracost generate config --out-file infracost.yml --template $template 
+    - name: Generate usage file
+      shell: pwsh
+      run: |
+        $usage = ""
+        
+        if ('${{ inputs.usage }}'.Trim() -ne '') {
+        $usage = @"
+        ${{ inputs.usage }}
+        "@ | Out-File -FilePath usage.yml
+        } else {
+        $usage = @"
+        version: 0.1
+        "@ | Out-File -FilePath usage.yml
+        }
     - name: Breakdown
       shell: pwsh
       run: |
-        infracost breakdown --config-file infracost.yml --out-file ${{ inputs.output-path }} --format json --fields all
+        infracost breakdown `
+          --config-file infracost.yml `
+          --out-file ${{ inputs.output-path }} `
+          --format json `
+          --fields all `
+          --sync-usage-file usage.yml

--- a/.github/actions/infracost/comment/README.md
+++ b/.github/actions/infracost/comment/README.md
@@ -4,16 +4,17 @@ Action: [breakdown](./action.yml)
 Add a comment to a GitHub PR
 
 ## Inputs
-| Name                  | Description                         | Required | Default  |
-|-----------------------|-------------------------------------|----------|----------|
-| `api-key`             | Infracost API Key                   | true     |          |
-| `behaviour`           | The behaviour for the comment       | false    | `update` |
-| `currency`            | The currency to show estimates in   | false    | `AUD`    |
-| `path`                | The path to the JSON report file    | true     |          |
-| `pull-request-number` | The PR number                       | true     |          |
-| `repository`          | The repository name                 | true     |          |
-| `token`               | The GitHub token                    | true     |          |
-| `version`             | The version of Infracost to install | false    | `0.10.x` |
+| Name                  | Description                                                         | Required | Default     |
+|-----------------------|---------------------------------------------------------------------|----------|-------------|
+| `api-key`             | Infracost API Key                                                   | true     |             |
+| `behaviour`           | The behaviour for the comment                                       | false    | `update`    |
+| `comment-identifier`  | A unique identifier to for the comment added by this implementation | false    | `infracost` |
+| `currency`            | The currency to show estimates in                                   | false    | `AUD`       |
+| `path`                | The path to the JSON report file                                    | true     |             |
+| `pull-request-number` | The PR number                                                       | true     |             |
+| `repository`          | The repository name                                                 | true     |             |
+| `token`               | The GitHub token                                                    | true     |             |
+| `version`             | The version of Infracost to install                                 | false    | `0.10.x`    |
 
 ## Example
 ```yaml
@@ -27,9 +28,10 @@ jobs:
         with:
           api-key: "${{ secrets.INFRACOST_API_KEY }}"
           behaviour: update
+          comment-identifier: production
           currency: AUD
           path: /tmp/diff.json
-          pull-request-number:
+          pull-request-number: ${{ github.event.number }}
           repository: ${{ github.repository }}
           token: ${{ github.token }}
           version: 0.10.x

--- a/.github/actions/infracost/comment/action.yml
+++ b/.github/actions/infracost/comment/action.yml
@@ -15,6 +15,11 @@ inputs:
       - hide-and-new
       - new
       - update
+  comment-identifier:
+    description: A unique identifier to for the comment added by this implementation
+    default: infracost
+    required: false
+    type: string
   currency:
     description: The currency to show estimates in
     default: AUD
@@ -60,4 +65,5 @@ runs:
           --pull-request=${{ inputs.pull-request-number }} `
           --github-token=${{ inputs.token }} `
           --behavior=${{ inputs.behaviour }} `
-          --show-all-projects
+          --show-all-projects `
+          --tag=infracost-${{ inputs.comment-identifier }}


### PR DESCRIPTION
# #25 - feat(actions): Add usage file support for infracost

[![Preview](https://github.com/cupel-co/actions/actions/workflows/preview.yml/badge.svg?branch=feat/GH-25-add-usage&event=pull_request)](https://github.com/cupel-co/actions/actions/workflows/preview.yml?query=branch%3Afeat/GH-25-add-usage)

## Description
* closes #25
* feat(actions): Add usage file support for infracost
* feat(actions): Add comment identifier support
