### PR TITLE
fix: set minor version for gitversion

### DIFF
--- a/.github/actions/version/generate/action.yml
+++ b/.github/actions/version/generate/action.yml
@@ -138,7 +138,7 @@ runs:
     - name: Install
       uses: gittools/actions/gitversion/setup@v1.1.1
       with:
-        versionSpec: '6.x'
+        versionSpec: '6.0.x'
     - name: Generate
       id: generate
       uses: gittools/actions/gitversion/execute@v1.1.1


### PR DESCRIPTION
# #27 - fix: set minor version for gitversion

[![Preview](https://github.com/cupel-co/actions/actions/workflows/preview.yml/badge.svg?branch=fix/GH-27-set-minor-version&event=pull_request)](https://github.com/cupel-co/actions/actions/workflows/preview.yml?query=branch%3Afix/GH-27-set-minor-version)

## Description
* closes #27
* 
* 
