### PR TITLE
feat: swap signing to use ssh key

### DIFF
--- a/.github/actions/release/tag/README.md
+++ b/.github/actions/release/tag/README.md
@@ -4,11 +4,11 @@ Action: [tag](action.yml)
 Create a tag
 
 ## Inputs
-| Name           | Description                  | Required | Default |
-|----------------|------------------------------|----------|---------|
-| `gpg-key`      | The GPG key.                 | true     |         |
-| `gpg-password` | The password for the GPG key | true     |         |
-| `tag`          | Tag value                    | true     |         |
+| Name                       | Description                          | Required | Default |
+|----------------------------|--------------------------------------|----------|---------|
+| `ssh-private-key`          | The private SSH key                  | true     |         |
+| `ssh-private-key-password` | The password for the private SSH key | true     |         |
+| `tag`                      | Tag value                            | true     |         |
 
 ## Example
 ```yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Create
         uses: cupel-co/actions/.github/actions/github/tag@vX.X.X
         with:
-          gpg-key: "${{ secrets.GH_GPG_KEY }}"
-          gpg-password: "${{ secrets.GH_GPG_KEY_PASSWORD }}"
+          ssh-private-key: "${{ secrets.SSH_PRIVATE_KEY }}"
+          ssh-private-key-password: "${{ secrets.SSH_PRIVATE_KEY_PASSWORD }}"
           tag: v1.0.0
 ```

--- a/.github/actions/release/tag/action.yml
+++ b/.github/actions/release/tag/action.yml
@@ -3,11 +3,11 @@ description: Create a tag
 author: Cupel
 
 inputs:
-  gpg-key:
-    description: The GPG key
+  ssh-private-key:
+    description: The private SSH key
     required: true
-  gpg-password:
-    description: The password for the GPG key
+  ssh-private-key-password:
+    description: The password for the private SSH key
     required: true
   tag:
     description: Tag value
@@ -16,18 +16,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v6
-      with:
-        gpg_private_key: '${{ inputs.gpg-key }}'
-        passphrase: '${{ inputs.gpg-password }}'
-        git_user_signingkey: true
-        git_tag_gpgsign: true
+    - name: Set up SSH
+      shell: bash
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ inputs.ssh-private-key }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        eval "$(ssh-agent -s)"
+        ssh-add ~/.ssh/id_ed25519 <<< "${{ inputs.ssh-private-key-password }}"
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
     - name: Create tag
       shell: bash
       run: |
-        exec git tag -s '${{ inputs.tag }}' -m '${{ inputs.tag }}'
+        git tag -s '${{ inputs.tag }}' -m '${{ inputs.tag }}'
     - name: Push tag
       shell: bash
       run: |
-        exec git push origin tag '${{ inputs.tag }}'
+        git push origin tag '${{ inputs.tag }}'

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -38,7 +38,7 @@ jobs:
       tag: v${{ needs.generate.outputs.sem-ver }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -47,15 +47,15 @@ jobs:
       - name: Tag
         uses: ./.github/actions/release/tag
         with:
-          gpg-key: '${{ secrets.GH_GPG_PRIVATE_KEY }}'
-          gpg-password: '${{ secrets.GH_GPG_PRIVATE_KEY_PASSWORD }}'
+          ssh-private-key: '${{ secrets.GH_SIGNING_SSH_PRIVATE_KEY }}'
+          ssh-private-key-password: '${{ secrets.GH_SIGNING_SSH_PRIVATE_KEY_PASSWORD }}'
           tag: '${{ env.tag }}'
-        
+
       - name: Release
         uses: ./.github/actions/release/create
         with:
           tag: '${{ env.tag }}'
-          token: '${{ secrets.GH_RELEASE_PAT }}'
+          token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Notify
         uses: ./.github/actions/release/notify


### PR DESCRIPTION
# #32 - feat: swap signing to use ssh key

[![Preview](https://github.com/cupel-co/actions/actions/workflows/preview.yml/badge.svg?branch=feat/GH-32-update-signing&event=pull_request)](https://github.com/cupel-co/actions/actions/workflows/preview.yml?query=branch%3Afeat/GH-32-update-signing)

## Description
* closes #32
* Swap signing to use ssh key
* 
